### PR TITLE
pin base images to cortex-python-lib latest-develop for now. Pin cortex-python to 6.3.1a1

### DIFF
--- a/templates/daemon/skills/__skillname__/actions/__skillname__/Dockerfile
+++ b/templates/daemon/skills/__skillname__/actions/__skillname__/Dockerfile
@@ -1,4 +1,4 @@
-FROM c12e/cortex-python-lib:fabric6
+FROM c12e/cortex-python-lib:latest-develop
 ADD . /app
 WORKDIR /app
 RUN pip install -r requirements.txt

--- a/templates/daemon/skills/__skillname__/actions/__skillname__/requirements.txt
+++ b/templates/daemon/skills/__skillname__/actions/__skillname__/requirements.txt
@@ -1,3 +1,3 @@
-cortex-python
+cortex-python==6.3.1a1
 fastapi
 uvicorn

--- a/templates/job/skills/__skillname__/actions/__skillname__/Dockerfile
+++ b/templates/job/skills/__skillname__/actions/__skillname__/Dockerfile
@@ -1,4 +1,4 @@
-FROM c12e/cortex-python-lib:fabric6
+FROM c12e/cortex-python-lib:latest-develop
 
 COPY --from=redboxoss/scuttle:latest /scuttle /bin/scuttle
 ENV ENVOY_ADMIN_API=http://localhost:15000

--- a/templates/job/skills/__skillname__/actions/__skillname__/Dockerfile
+++ b/templates/job/skills/__skillname__/actions/__skillname__/Dockerfile
@@ -1,6 +1,5 @@
 FROM c12e/cortex-python-lib:latest-develop
 
-COPY --from=redboxoss/scuttle:latest /scuttle /bin/scuttle
 ENV ENVOY_ADMIN_API=http://localhost:15000
 ENV ISTIO_QUIT_API=http://localhost:15020
 ENV SCUTTLE_LOGGING=false

--- a/templates/job/skills/__skillname__/actions/__skillname__/requirements.txt
+++ b/templates/job/skills/__skillname__/actions/__skillname__/requirements.txt
@@ -1,1 +1,1 @@
-cortex-python
+cortex-python==6.3.1a1

--- a/templates/jobchaining/skills/dataconsumer/actions/dataconsumer/Dockerfile
+++ b/templates/jobchaining/skills/dataconsumer/actions/dataconsumer/Dockerfile
@@ -1,4 +1,4 @@
-FROM c12e/cortex-python-lib:fabric6
+FROM c12e/cortex-python-lib:latest-develop
 WORKDIR /app
 COPY requirements.txt /app
 COPY *.py /app

--- a/templates/jobchaining/skills/dataconsumer/actions/dataconsumer/job.py
+++ b/templates/jobchaining/skills/dataconsumer/actions/dataconsumer/job.py
@@ -4,7 +4,6 @@ Copyright (c) 2020. Cognitive Scale Inc. All rights reserved.
 Licensed under CognitiveScale Example Code [License](https://cognitivescale.github.io/cortex-fabric-examples/LICENSE.md)
 """
 from cortex import Cortex
-from cortex.content import ManagedContentClient
 import pandas as pd
 import sys
 import json
@@ -24,10 +23,9 @@ def process(params):
         content_key = payload['datafileKey']
     print(f'Fetching datafile from managed content: {content_key}')
     # use the `client` instance to use Cortex client libraries
-    content_client = ManagedContentClient(client);
     # This is streaming the records to Cortex's managed content
     # if this was called as part of an agent
-    content = content_client.download(content_key)
+    content = client.content.download(content_key)
     df = pd.read_json(content, lines=True)
     counts = df['color'].value_counts()
     print(f'{counts.to_json()}')

--- a/templates/jobchaining/skills/dataconsumer/actions/dataconsumer/requirements.txt
+++ b/templates/jobchaining/skills/dataconsumer/actions/dataconsumer/requirements.txt
@@ -1,2 +1,2 @@
-cortex-python
+cortex-python==6.3.1a1
 pandas

--- a/templates/jobchaining/skills/datagenerator/actions/datagenerator/Dockerfile
+++ b/templates/jobchaining/skills/datagenerator/actions/datagenerator/Dockerfile
@@ -1,4 +1,4 @@
-FROM c12e/cortex-python-lib:fabric6
+FROM c12e/cortex-python-lib:latest-develop
 WORKDIR /app
 COPY requirements.txt /app
 COPY *.py /app

--- a/templates/jobchaining/skills/datagenerator/actions/datagenerator/job.py
+++ b/templates/jobchaining/skills/datagenerator/actions/datagenerator/job.py
@@ -4,7 +4,6 @@ Copyright (c) 2020. Cognitive Scale Inc. All rights reserved.
 Licensed under CognitiveScale Example Code [License](https://cognitivescale.github.io/cortex-fabric-examples/LICENSE.md)
 """
 from cortex import Cortex
-from cortex.content import ManagedContentClient
 import json
 import sys
 import time
@@ -28,7 +27,6 @@ def process(params):
     # You can print logs to the console these are collected by docker/k8s
     print(f'Got payload: {payload}')
     # use the `client` instance to use Cortex client libraries
-    content_client = ManagedContentClient(client);
     if 'activationId' in params:
         file_name = f'jobchain-data-{params["activationId"]}'
     else:
@@ -37,7 +35,7 @@ def process(params):
     # Read `recordCount` from payload, have a default value of raising an Exception is recommended.
     record_count = payload.get('recordCount', 1000)
     # This is streaming the records to Cortex's managed content
-    content_client.upload_streaming(file_name, datagen_stream(record_count), 'application/x-jsonlines')
+    client.content.upload_streaming(file_name, datagen_stream(record_count), 'application/x-jsonlines')
     print(f'Wrote datafile to managed content key: {file_name}')
 
 if __name__ == "__main__":

--- a/templates/jobchaining/skills/datagenerator/actions/datagenerator/requirements.txt
+++ b/templates/jobchaining/skills/datagenerator/actions/datagenerator/requirements.txt
@@ -1,2 +1,2 @@
-cortex-python
+cortex-python==6.3.1a1
 Faker

--- a/templates/jobwebhook/simplejob/actions/default-action/Dockerfile
+++ b/templates/jobwebhook/simplejob/actions/default-action/Dockerfile
@@ -1,4 +1,4 @@
-FROM c12e/cortex-python-lib:fabric6
+FROM c12e/cortex-python-lib:latest-develop
 WORKDIR /app
 COPY requirements.txt /app
 COPY *.py /app

--- a/templates/jobwebhook/webhook/actions/default-action/Dockerfile
+++ b/templates/jobwebhook/webhook/actions/default-action/Dockerfile
@@ -1,4 +1,4 @@
-FROM c12e/cortex-python-lib:fabric6
+FROM c12e/cortex-python-lib:latest-develop
 WORKDIR /app
 COPY requirements.txt /app
 COPY *.py /app

--- a/templates/managed-content-counter/skills/__skillname__-view/actions/__skillname__-view/Dockerfile
+++ b/templates/managed-content-counter/skills/__skillname__-view/actions/__skillname__-view/Dockerfile
@@ -1,4 +1,4 @@
-FROM c12e/cortex-python-lib:fabric6
+FROM c12e/cortex-python-lib:latest-develop
 
 COPY --from=redboxoss/scuttle:latest /scuttle /bin/scuttle
 ENV ENVOY_ADMIN_API=http://localhost:15000

--- a/templates/managed-content-counter/skills/__skillname__-view/actions/__skillname__-view/Dockerfile
+++ b/templates/managed-content-counter/skills/__skillname__-view/actions/__skillname__-view/Dockerfile
@@ -1,6 +1,5 @@
 FROM c12e/cortex-python-lib:latest-develop
 
-COPY --from=redboxoss/scuttle:latest /scuttle /bin/scuttle
 ENV ENVOY_ADMIN_API=http://localhost:15000
 ENV ISTIO_QUIT_API=http://localhost:15020
 ENV SCUTTLE_LOGGING=false

--- a/templates/managed-content-counter/skills/__skillname__-view/actions/__skillname__-view/main.py
+++ b/templates/managed-content-counter/skills/__skillname__-view/actions/__skillname__-view/main.py
@@ -6,7 +6,7 @@ Licensed under CognitiveScale Template/Example Code [License](https://github.com
 
 import json
 import sys
-from cortex.content import ManagedContentClient
+from cortex import Cortex
 
 
 # The starting point for the job
@@ -20,7 +20,7 @@ if __name__ == '__main__':
         project_id = payload.get('projectId', request_body['projectId'])
 
         # Create ManagedContentClient.
-        content_client = ManagedContentClient(url=url, token=token, project=project_id)
+        content_client = Cortex.client(api_endpoint=url, token=token, project=project_id).content
         key = payload['key']
 
         # Download data from managed content.

--- a/templates/managed-content-counter/skills/__skillname__-view/actions/__skillname__-view/requirements.txt
+++ b/templates/managed-content-counter/skills/__skillname__-view/actions/__skillname__-view/requirements.txt
@@ -1,1 +1,1 @@
-cortex-python
+cortex-python==6.3.1a1

--- a/templates/managed-content-counter/skills/__skillname__/actions/__skillname__/Dockerfile
+++ b/templates/managed-content-counter/skills/__skillname__/actions/__skillname__/Dockerfile
@@ -1,4 +1,4 @@
-FROM c12e/cortex-python-lib:fabric6
+FROM c12e/cortex-python-lib:latest-develop
 ADD . /app
 WORKDIR /app
 RUN pip install -r requirements.txt

--- a/templates/managed-content-counter/skills/__skillname__/actions/__skillname__/main.py
+++ b/templates/managed-content-counter/skills/__skillname__/actions/__skillname__/main.py
@@ -5,7 +5,7 @@ Licensed under CognitiveScale Template/Example Code [License](https://github.com
 """
 
 from fastapi import FastAPI
-from cortex.content import ManagedContentClient
+from cortex import Cortex
 
 app = FastAPI()
 
@@ -19,8 +19,7 @@ def run(request_body: dict):
     if payload:
         project_id = payload.get('projectId', request_body['projectId'])
 
-        # Create ManagedContentClient.
-        content_client = ManagedContentClient(url=url, token=token, project=project_id)
+        content_client = Cortex.client(api_endpoint=url, token=token, project=project_id).content
         key = payload['key']
         modifier = int(payload['modifier'])
         operator = payload['command']

--- a/templates/managed-content-counter/skills/__skillname__/actions/__skillname__/requirements.txt
+++ b/templates/managed-content-counter/skills/__skillname__/actions/__skillname__/requirements.txt
@@ -1,3 +1,3 @@
-cortex-python
+cortex-python==6.3.1a1
 fastapi
 uvicorn

--- a/templates/managed-content-example-job/skills/__skillname__/actions/__skillname__/Dockerfile
+++ b/templates/managed-content-example-job/skills/__skillname__/actions/__skillname__/Dockerfile
@@ -1,4 +1,4 @@
-FROM c12e/cortex-python-lib:fabric6
+FROM c12e/cortex-python-lib:latest-develop
 
 COPY --from=redboxoss/scuttle:latest /scuttle /bin/scuttle
 ENV ENVOY_ADMIN_API=http://localhost:15000

--- a/templates/managed-content-example-job/skills/__skillname__/actions/__skillname__/Dockerfile
+++ b/templates/managed-content-example-job/skills/__skillname__/actions/__skillname__/Dockerfile
@@ -1,6 +1,5 @@
 FROM c12e/cortex-python-lib:latest-develop
 
-COPY --from=redboxoss/scuttle:latest /scuttle /bin/scuttle
 ENV ENVOY_ADMIN_API=http://localhost:15000
 ENV ISTIO_QUIT_API=http://localhost:15020
 ENV SCUTTLE_LOGGING=false

--- a/templates/managed-content-example-job/skills/__skillname__/actions/__skillname__/main.py
+++ b/templates/managed-content-example-job/skills/__skillname__/actions/__skillname__/main.py
@@ -6,7 +6,7 @@ Licensed under CognitiveScale Template/Example Code [License](https://github.com
 
 import json
 import sys
-from cortex.content import ManagedContentClient
+from cortex import Cortex
 
 
 # The starting point for the job
@@ -20,7 +20,7 @@ if __name__ == '__main__':
         project_id = payload.get('projectId', request_body['projectId'])
 
         # Create ManagedContentClient.
-        content_client = ManagedContentClient(url=url, token=token, project=project_id)
+        content_client = Cortex.client(api_endpoint=url, token=token, project=project_id).content
         key = payload['key']
 
         if payload['command'] == 'download':

--- a/templates/managed-content-example-job/skills/__skillname__/actions/__skillname__/requirements.txt
+++ b/templates/managed-content-example-job/skills/__skillname__/actions/__skillname__/requirements.txt
@@ -1,1 +1,1 @@
-cortex-python
+cortex-python==6.3.1a1

--- a/templates/online-prediction/skills/__skillname__/actions/__skillname__-action/Dockerfile
+++ b/templates/online-prediction/skills/__skillname__/actions/__skillname__-action/Dockerfile
@@ -1,4 +1,4 @@
-FROM c12e/cortex-python-lib:fabric6
+FROM c12e/cortex-python-lib:latest-develop
 ADD . /app
 WORKDIR /app
 RUN pip install -r requirements.txt

--- a/templates/online-prediction/skills/__skillname__/actions/__skillname__-action/predict/model_flow.py
+++ b/templates/online-prediction/skills/__skillname__/actions/__skillname__-action/predict/model_flow.py
@@ -9,6 +9,7 @@ import logging
 import numpy as np
 import pandas as pd
 from cortex import Cortex
+from cortex.experiment import Experiment
 
 from predict.request_models import InvokeRequest
 
@@ -27,7 +28,7 @@ def load_model(api_endpoint: str, token: str, project_id: str, experiment_name: 
     # Load Model from the experiment run
     logging.info("Loading model artifacts from experiment run...")
     try:
-        experiment = client.experiment(experiment_name)
+        experiment = Experiment(client.experiments.get_experiment(experiment_name), client.experiments)
         run = experiment.get_run(run_id) if run_id else experiment.last_run()
         model = run.get_artifact('model')
     except Exception as e:

--- a/templates/online-prediction/skills/__skillname__/actions/__skillname__-action/requirements.txt
+++ b/templates/online-prediction/skills/__skillname__/actions/__skillname__-action/requirements.txt
@@ -1,5 +1,5 @@
 pandas
-cortex-python
+cortex-python==6.3.1a1
 fastapi
 uvicorn
 catboost

--- a/templates/simple-experiment/skills/__skillname__-predict/actions/__skillname__-predict/Dockerfile
+++ b/templates/simple-experiment/skills/__skillname__-predict/actions/__skillname__-predict/Dockerfile
@@ -1,4 +1,4 @@
-FROM c12e/cortex-python-lib:fabric6
+FROM c12e/cortex-python-lib:latest-develop
 ADD . /app
 WORKDIR /app
 RUN pip install -r requirements.txt

--- a/templates/simple-experiment/skills/__skillname__-predict/actions/__skillname__-predict/main.py
+++ b/templates/simple-experiment/skills/__skillname__-predict/actions/__skillname__-predict/main.py
@@ -5,6 +5,7 @@ Licensed under CognitiveScale Template/Example Code [License](https://github.com
 """
 
 from cortex import Cortex
+from cortex.experiment import Experiment
 from fastapi import FastAPI
 
 app = FastAPI()
@@ -21,7 +22,7 @@ def run(request_body: dict):
 
     # Create Cortex client and get experiment
     client = Cortex.client(api_endpoint=api_endpoint, project=project, token=token)
-    experiment = client.experiment(experiment_name)
+    experiment = Experiment(client.experiments.get_experiment(experiment_name), client.experiments)
 
     # Get model from last experiment run
     exp_run = experiment.last_run()

--- a/templates/simple-experiment/skills/__skillname__-predict/actions/__skillname__-predict/requirements.txt
+++ b/templates/simple-experiment/skills/__skillname__-predict/actions/__skillname__-predict/requirements.txt
@@ -1,4 +1,4 @@
-cortex-python
+cortex-python==6.3.1a1
 fastapi
 uvicorn
 scikit-learn

--- a/templates/simple-experiment/skills/__skillname__-train/actions/__skillname__-train/Dockerfile
+++ b/templates/simple-experiment/skills/__skillname__-train/actions/__skillname__-train/Dockerfile
@@ -1,4 +1,4 @@
-FROM c12e/cortex-python-lib:fabric6
+FROM c12e/cortex-python-lib:latest-develop
 
 COPY --from=redboxoss/scuttle:latest /scuttle /bin/scuttle
 ENV ENVOY_ADMIN_API=http://localhost:15000

--- a/templates/simple-experiment/skills/__skillname__-train/actions/__skillname__-train/Dockerfile
+++ b/templates/simple-experiment/skills/__skillname__-train/actions/__skillname__-train/Dockerfile
@@ -1,6 +1,5 @@
 FROM c12e/cortex-python-lib:latest-develop
 
-COPY --from=redboxoss/scuttle:latest /scuttle /bin/scuttle
 ENV ENVOY_ADMIN_API=http://localhost:15000
 ENV ISTIO_QUIT_API=http://localhost:15020
 ENV SCUTTLE_LOGGING=false

--- a/templates/simple-experiment/skills/__skillname__-train/actions/__skillname__-train/main.py
+++ b/templates/simple-experiment/skills/__skillname__-train/actions/__skillname__-train/main.py
@@ -9,6 +9,7 @@ import json
 import pickle
 import numpy as np
 from cortex import Cortex
+from cortex.experiment import Experiment
 from sklearn import datasets
 from sklearn.ensemble import RandomForestClassifier
 
@@ -42,7 +43,7 @@ if __name__ == '__main__':
 
     # Create Cortex client and create experiment
     client = Cortex.client(api_endpoint=api_endpoint, project=project, token=token)
-    experiment = client.experiment(experiment_name)
+    experiment = Experiment(client.experiments.get_experiment(experiment_name), client.experiments)
 
     # Upload model to experiment run in Cortex
     model = open(local_pickle_file, "rb")

--- a/templates/simple-experiment/skills/__skillname__-train/actions/__skillname__-train/requirements.txt
+++ b/templates/simple-experiment/skills/__skillname__-train/actions/__skillname__-train/requirements.txt
@@ -1,2 +1,2 @@
-cortex-python
+cortex-python==6.3.1a1
 scikit-learn

--- a/templates/word-count-agent/skills/__skillname__/actions/__skillname__/Dockerfile
+++ b/templates/word-count-agent/skills/__skillname__/actions/__skillname__/Dockerfile
@@ -1,4 +1,4 @@
-FROM c12e/cortex-python-lib:fabric6
+FROM c12e/cortex-python-lib:latest-develop
 ADD . /app
 WORKDIR /app
 RUN pip install -r requirements.txt


### PR DESCRIPTION
We should ideally pin the base image to a tag generated off of main or staging. Leaving it at latest-develop for now. Need to update these files again when we have the 6.3.1 pyib release out on Pypi as a stable release